### PR TITLE
fix: the service flag should be set to 0x00 since it’s an SPV node

### DIFF
--- a/internal/wire/protocol.go
+++ b/internal/wire/protocol.go
@@ -59,6 +59,9 @@ const (
 // ServiceFlag identifies services supported by a bitcoin peer.
 type ServiceFlag uint64
 
+// SFspv is for Simplified Payment Verification nodes which only download headers.
+const SFspv ServiceFlag = 0
+
 const (
 	// SFNodeNetwork is a flag used to indicate a peer is a full node.
 	SFNodeNetwork ServiceFlag = 1 << iota

--- a/transports/p2p/connmgr/seed.go
+++ b/transports/p2p/connmgr/seed.go
@@ -36,7 +36,7 @@ func SeedFromDNS(chainParams *chaincfg.Params, reqServices wire.ServiceFlag,
 
 	for _, dnsseed := range chainParams.DNSSeeds {
 		var host string
-		if !dnsseed.HasFiltering || reqServices == wire.SFNodeNetwork {
+		if !dnsseed.HasFiltering || reqServices == wire.SFNodeNetwork || reqServices == wire.SFspv {
 			host = dnsseed.Host
 		} else {
 			host = fmt.Sprintf("x%x.%s", uint64(reqServices), dnsseed.Host)

--- a/transports/p2p/server.go
+++ b/transports/p2p/server.go
@@ -34,11 +34,11 @@ import (
 const (
 	// defaultServices describes the default services that are supported by
 	// the server.
-	defaultServices = wire.SFNodeNetwork | wire.SFNodeCF | wire.SFNodeBitcoinCash
+	defaultServices = 0
 
 	// defaultRequiredServices describes the default services that are
 	// required to be supported by outbound peers.
-	defaultRequiredServices = wire.SFNodeNetwork
+	defaultRequiredServices = 0 // This 0 allows Pulse instances to connect to each other.
 
 	// connectionRetryInterval is the base amount of time to wait in between
 	// retries when connecting to persistent peers.  It is adjusted by the
@@ -47,12 +47,12 @@ const (
 
 	// userAgentName is the user agent name and is used to help identify
 	// ourselves to other bitcoin peers.
-	userAgentName = "/bsv"
+	userAgentName = "/Pulse"
 
 	// userAgentVersion is the user agent version and is used to help
 	// identify ourselves to other bitcoin peers.
 	// userAgentVersion = fmt.Sprintf("%d.%d.%d", version.AppMajor, version.AppMinor, version.AppPatch).
-	userAgentVersion = "1.0.11"
+	userAgentVersion = "0.3.0"
 )
 
 var (

--- a/transports/p2p/server.go
+++ b/transports/p2p/server.go
@@ -34,11 +34,11 @@ import (
 const (
 	// defaultServices describes the default services that are supported by
 	// the server.
-	defaultServices = 0
+	defaultServices = wire.SFspv
 
 	// defaultRequiredServices describes the default services that are
 	// required to be supported by outbound peers.
-	defaultRequiredServices = 0 // This 0 allows Pulse instances to connect to each other.
+	defaultRequiredServices = wire.SFspv
 
 	// connectionRetryInterval is the base amount of time to wait in between
 	// retries when connecting to persistent peers.  It is adjusted by the


### PR DESCRIPTION
# Pull Request Checklist

- [x] 📖 I created my PR using provided  : [CODE_STANDARDS](https://github.com/bitcoin-sv/pulse/blob/main/.github/CODE_STANDARDS.md)
- [x] 📖 I have read the short Code of Conduct: [CODE_OF_CONDUCT](https://github.com/bitcoin-sv/pulse/blob/main/.github/CODE_OF_CONDUCT.md)
- [ ] 🏠 I tested my changes locally.
- [ ] ✅ I have provided tests for my changes.
- [x] 📝 I have used conventional commits.
- [ ] 📗 I have updated any related documentation.
- [ ] 💾 PR was issued based on the Github or Jira issue.

## Feature/Issue Details
The service flag should be set to 0x00 since it’s an [SPV node](https://github.com/bitcoin-sv/bitcoin-sv/blob/e31cc4356d8ebc48d10488f69ab3302807bf20f4/src/protocol.h#L457) which cannot provide services to other nodes.
Also update the user agents so we can see how this looks from the NOC