### PR TITLE
feat(BUX-565) metrics of the latest block

### DIFF
--- a/metrics/latest_block.go
+++ b/metrics/latest_block.go
@@ -1,0 +1,26 @@
+package metrics
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type latestBlockMetrics struct {
+	height    *prometheus.GaugeVec
+	timestamp *prometheus.GaugeVec
+}
+
+func registerLatestBlockMetrics(reg prometheus.Registerer) *latestBlockMetrics {
+	return &latestBlockMetrics{
+		height:    registerGaugeVec(reg, latestBlockHeightName, []string{"state"}),
+		timestamp: registerGaugeVec(reg, latestBlockTimestampName, []string{"state"}),
+	}
+}
+
+func SetLatestBlock(height int32, timestamp time.Time, state string) {
+	if metrics, enabled := Get(); enabled {
+		metrics.latestBlock.height.WithLabelValues(state).Set(float64(height))
+		metrics.latestBlock.timestamp.WithLabelValues(state).Set(float64(timestamp.Unix()))
+	}
+}

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -8,6 +8,7 @@ type Metrics struct {
 	gatherer     prometheus.Gatherer
 	registerer   prometheus.Registerer
 	httpRequests *RequestMetrics
+	latestBlock  *latestBlockMetrics
 }
 
 func newMetrics() *Metrics {
@@ -19,6 +20,7 @@ func newMetrics() *Metrics {
 		gatherer:     registry,
 		registerer:   registererWithLabels,
 		httpRequests: registerRequestMetrics(registererWithLabels),
+		latestBlock:  registerLatestBlockMetrics(registererWithLabels),
 	}
 
 	return m

--- a/metrics/naming.go
+++ b/metrics/naming.go
@@ -8,6 +8,6 @@ const requestDurationSecName = requestMetricBaseName + "_duration_seconds"
 
 const domainPrefix = "bux_"
 
-const latestBlockBlockBase = domainPrefix + "latest_block"
-const latestBlockHeightName = latestBlockBlockBase + "_height"
-const latestBlockTimestampName = latestBlockBlockBase + "_timestamp"
+const latestBlockBaseName = domainPrefix + "latest_block"
+const latestBlockHeightName = latestBlockBaseName + "_height"
+const latestBlockTimestampName = latestBlockBaseName + "_timestamp"

--- a/metrics/naming.go
+++ b/metrics/naming.go
@@ -5,3 +5,9 @@ const appName = "pulse"
 const requestMetricBaseName = "http_request"
 const requestCounterName = requestMetricBaseName + "_total"
 const requestDurationSecName = requestMetricBaseName + "_duration_seconds"
+
+const domainPrefix = "bux_"
+
+const latestBlockBlockBase = domainPrefix + "latest_block"
+const latestBlockHeightName = latestBlockBlockBase + "_height"
+const latestBlockTimestampName = latestBlockBlockBase + "_timestamp"

--- a/metrics/vec.go
+++ b/metrics/vec.go
@@ -14,6 +14,18 @@ func registerCounterVec(reg prometheus.Registerer, name string, labels []string)
 	return c
 }
 
+func registerGaugeVec(reg prometheus.Registerer, name string, labels []string) *prometheus.GaugeVec {
+	g := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: name,
+			Help: "Gauge of " + name,
+		},
+		labels,
+	)
+	reg.MustRegister(g)
+	return g
+}
+
 func registerDurationHistogram(reg prometheus.Registerer, name string, labels []string) *prometheus.HistogramVec {
 	h := prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{

--- a/service/chain_service.go
+++ b/service/chain_service.go
@@ -4,6 +4,7 @@ import (
 	"github.com/bitcoin-sv/pulse/domains"
 	"github.com/bitcoin-sv/pulse/internal/chaincfg"
 	"github.com/bitcoin-sv/pulse/internal/chaincfg/chainhash"
+	"github.com/bitcoin-sv/pulse/metrics"
 	"github.com/bitcoin-sv/pulse/repository"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
@@ -96,6 +97,7 @@ func (cs *chainService) Add(bs domains.BlockHeaderSource) (*domains.BlockHeader,
 		return nil, err
 	}
 
+	metrics.SetLatestBlock(h.Height, h.Timestamp, h.State.String())
 	cs.notification.Notify(domains.HeaderAdded(h))
 	return h, err
 }


### PR DESCRIPTION
<!-- 
    Thank you for contributing to our project! Before you submit your Pull Request, please make sure you've completed the items in this checklist.
    Please check the boxes below by putting an x in the [ ] like so: [x]. You can do it right after creating the PR.
-->

# Pull Request Checklist

- [x] 📖 I created my PR using provided  : [CODE_STANDARDS](https://github.com/bitcoin-sv/pulse/blob/main/.github/CODE_STANDARDS.md)
- [x] 📖 I have read the short Code of Conduct: [CODE_OF_CONDUCT](https://github.com/bitcoin-sv/pulse/blob/main/.github/CODE_OF_CONDUCT.md)
- [ ] 🏠 I tested my changes locally.
- [ ] ✅ I have provided tests for my changes.
- [x] 📝 I have used conventional commits.
- [ ] 📗 I have updated any related documentation.
- [x] 💾 PR was issued based on the Github or Jira issue.

Every new block header comes, it is recorded by two metric gauges: `bux_latest_block_height` & `bux_latest_block_timestamp`. Based on these, the following visualizations can be made:

![Zrzut ekranu 2024-02-05 150452](https://github.com/bitcoin-sv/pulse/assets/152964795/e91e833b-7806-41d4-be1c-fbf05f452834)

Additionally, the pulse-out-of-sync alert (described in BUX-307) can be configured:

![Zrzut ekranu 2024-02-05 140809](https://github.com/bitcoin-sv/pulse/assets/152964795/a56b0f98-10bd-4606-bdca-931ae8ff3c02)

Of course, the trigger out-of-sync time in sec is configurable and in the real world installation it should be found during experiments & based on blockchain specification.

For example, as you can see on the screen, sometimes a new block is mined in about 30 minutes.

<!-- 
## PR Title as Conventional Commit

Your PR title should also be a [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/). This will assist us in our release process and in assigning semantic version numbers to releases.
-->

<!-- 
## Related Tickets & Documents

If your changes relate to or close an issue, please include them below. We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For instance, having the text "closes #1234" would link the current pull request to issue number 1234. And when we merge the pull request, Github will automatically close the issue.

- Related Issue #
- Closes #
-->

<!--
## Feature/Issue Details

Your pull request should be tightly connected to a feature or issue. Ensure that you've covered all necessary pathways and there's a possibility to test code behavior following the issue description or feature specification.
-->
